### PR TITLE
Add Gather Command and Tests

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -130,6 +130,8 @@ The `Model` component,
 
 <img src="images/BetterModelClassDiagram.png" width="450" />
 
+This approach is also use for `FinancialPlan`. The multiple `Tag` and `FinancialPlan` objects are stored in their respective `HashSet` where each object in the `HashSet` will have a corresponding hashcode.
+
 </div>
 
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -85,7 +85,7 @@ Format: `help`
 
 Add a client’s contacts to address book (name, phone number, email, home address, next-of-kin name, next-of-kin phone number) into Address Book
 
-Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS nk/NEXT_KIN nkp/NEXT_KIN_PHONE [t/TAG]…​`
+Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS nk/NEXT_KIN nkp/NEXT_KIN_PHONE [fp/FINICIAL_PLAN] [t/TAG]…​`
 
 Acceptable Values: 
 1. NAME - any value is possible
@@ -96,6 +96,7 @@ Acceptable Values:
 6. NEXT_KIN_PHONE - Numbers (0-9), and symbols, no alphabets
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+A person can have any number of Financial Plans (including 0)
 A person can have any number of tags (including 0)
 </div>
 
@@ -118,9 +119,11 @@ Format: `edit ENTRY_INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [nk/NE
 * Edits the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
-* When editing tags, the existing tags of the person will be removed i.e adding of tags is not cumulative.
+* When editing financial plans or tags, the existing financial plans or tags of the person will be removed i.e adding of tags is not cumulative.
 * You can remove all the person’s tags by typing `t/` without
     specifying any tags after it.
+* You can remove all the person’s financial plans by typing `fp/` without
+  specifying any tags after it.
 
 Acceptable Values:
 1. ENTRY_INDEX - Number (1 to current size of the address book)
@@ -130,6 +133,7 @@ Acceptable Values:
 5. ADDRESS - any value is possible
 6. NEXT_KIN - any value is possible
 7. NEXT_KIN_PHONE - Numbers (0-9), and symbols, no alphabets
+8. FINANCIAL_PLAN - Alphanumeric or Space characters
 
 Examples:
 *  `edit 1 n/john doe a/23 woodlands ave 123` Edits the name and address of the 1st person to be `john doe` and `woodlands ave 123` respectively.
@@ -160,6 +164,21 @@ Examples:
 * `find John` returns `john` and `John Doe`
 * `find alex david` returns `Alex Yeoh`, `David Li`<br>
   ![result for 'find alex david'](images/findAlexDavidResult.png)
+
+### Gathering clients' emails by financial plan: `gather`
+
+Gathers all the emails of persons with a desired financial plan.
+
+Format: `gather PROMPT`
+
+* The search is case-sensitive. e.g `fp` will not match `Fp`
+* Persons matching at least one financial plan will be returned (i.e. `OR` search).
+
+Examples:
+* `gather Financial Plan A`
+
+Successful Output:
+`lowjunyu@gmail.com johndoe@gmail.com`
 
 ### Deleting a client's contact : `delete`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -85,7 +85,7 @@ Format: `help`
 
 Add a client’s contacts to address book (name, phone number, email, home address, next-of-kin name, next-of-kin phone number) into Address Book
 
-Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS nk/NEXT_KIN nkp/NEXT_KIN_PHONE [fp/FINICIAL_PLAN] [t/TAG]…​`
+Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS nk/NEXT_KIN nkp/NEXT_KIN_PHONE [fp/FINANCIAL_PLAN] [t/TAG]…​`
 
 Acceptable Values: 
 1. NAME - any value is possible

--- a/src/main/java/seedu/address/logic/commands/GatherCommand.java
+++ b/src/main/java/seedu/address/logic/commands/GatherCommand.java
@@ -16,7 +16,7 @@ public class GatherCommand extends Command {
             + "Parameters: FINANCIAL_PLAN\n"
             + "Example: " + COMMAND_WORD + " Sample Financial Plan 1";
 
-    public static final String MESSAGE_NO_PERSON_FOUND = "0 Person were found with ";
+    public static final String MESSAGE_NO_PERSON_FOUND = "0 persons were found with ";
 
     private final String prompt;
 

--- a/src/main/java/seedu/address/logic/commands/GatherCommand.java
+++ b/src/main/java/seedu/address/logic/commands/GatherCommand.java
@@ -1,0 +1,67 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.Model;
+
+/**
+ * Gathers and lists all persons in address book emails whose details contain a given Financial Plan.
+ * Keyword matching is case sensitive.
+ */
+public class GatherCommand extends Command {
+
+    public static final String COMMAND_WORD = "gather";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Gathers all the persons emails whose financial "
+            + "plan matches the desired financial plan and display it on the output.\n"
+            + "Parameters: FINANCIAL_PLAN\n"
+            + "Example: " + COMMAND_WORD + " Sample Financial Plan 1";
+
+    public static final String MESSAGE_NO_PERSON_FOUND = "No Person were found with ";
+
+    private final String prompt;
+
+    /**
+     * Constructs a new GatherCommand object.
+     * @param prompt The user's prompt
+     */
+    public GatherCommand(String prompt) {
+        this.prompt = prompt;
+    }
+
+    /**
+     * Overrides Command execute method.
+     * @param model {@code Model} which the command should operate on.
+     * @return The CommandResult depending on the user input
+     */
+    @Override
+    public CommandResult execute(Model model) {
+        String emails = model.gatherEmails(prompt);
+        if (emails.isEmpty()) {
+            return new CommandResult(MESSAGE_NO_PERSON_FOUND + prompt);
+        }
+        return new CommandResult(emails);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof GatherCommand)) {
+            return false;
+        }
+
+        GatherCommand otherGatherCommand = (GatherCommand) other;
+        return prompt.equals(otherGatherCommand.prompt);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("prompt", prompt)
+                .toString();
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/GatherCommand.java
+++ b/src/main/java/seedu/address/logic/commands/GatherCommand.java
@@ -16,7 +16,7 @@ public class GatherCommand extends Command {
             + "Parameters: FINANCIAL_PLAN\n"
             + "Example: " + COMMAND_WORD + " Sample Financial Plan 1";
 
-    public static final String MESSAGE_NO_PERSON_FOUND = "No Person were found with ";
+    public static final String MESSAGE_NO_PERSON_FOUND = "0 Person were found with ";
 
     private final String prompt;
 

--- a/src/main/java/seedu/address/logic/commands/GatherCommand.java
+++ b/src/main/java/seedu/address/logic/commands/GatherCommand.java
@@ -11,7 +11,7 @@ public class GatherCommand extends Command {
 
     public static final String COMMAND_WORD = "gather";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Gathers all the persons emails whose financial "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Gathers all emails of person whose financial "
             + "plan matches the desired financial plan and display it on the output.\n"
             + "Parameters: FINANCIAL_PLAN\n"
             + "Example: " + COMMAND_WORD + " Sample Financial Plan 1";

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.GatherCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -76,6 +77,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case GatherCommand.COMMAND_WORD:
+            return new GatherCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/GatherCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/GatherCommandParser.java
@@ -9,6 +9,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new GatherCommand object
  */
 public class GatherCommandParser implements Parser<GatherCommand> {
+    public static final String VALIDATION_REGEX = "^[a-zA-Z0-9\\s]+";
+    public static final String MESSAGE_CONSTRAINTS = "PROMPT should be alphanumeric or space characters";
 
     /**
      * Parses the given {@code String} of arguments in the context of the GatherCommand
@@ -20,6 +22,11 @@ public class GatherCommandParser implements Parser<GatherCommand> {
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, GatherCommand.MESSAGE_USAGE));
+        }
+
+        if (!trimmedArgs.matches(VALIDATION_REGEX)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_CONSTRAINTS));
         }
 
         return new GatherCommand(trimmedArgs);

--- a/src/main/java/seedu/address/logic/parser/GatherCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/GatherCommandParser.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.GatherCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new GatherCommand object
+ */
+public class GatherCommandParser implements Parser<GatherCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the GatherCommand
+     * and returns a GatherCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public GatherCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, GatherCommand.MESSAGE_USAGE));
+        }
+
+        return new GatherCommand(trimmedArgs);
+    }
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -97,7 +97,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     /**
      * Gathers the persons emails with {@code prompt} from this {@code AddressBook}.
      */
-    public String gatherPersons(String prompt) {
+    public String gatherEmails(String prompt) {
         return persons.gatherEmails(prompt);
     };
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -94,6 +94,13 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons.remove(key);
     }
 
+    /**
+     * Gathers the persons emails with {@code prompt} from this {@code AddressBook}.
+     */
+    public String gatherPersons(String prompt) {
+        return persons.gatherEmails(prompt);
+    };
+
     //// util methods
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -84,4 +84,11 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Gathers the emails of person with the given prompt.
+     * @param prompt The user input for command
+     * @return The String representation of all the gathered emails.
+     */
+    String gatherEmails(String prompt);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -113,7 +113,7 @@ public class ModelManager implements Model {
 
     @Override
     public String gatherEmails(String prompt) {
-        return addressBook.gatherPersons(prompt);
+        return addressBook.gatherEmails(prompt);
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -111,6 +111,11 @@ public class ModelManager implements Model {
         addressBook.setPerson(target, editedPerson);
     }
 
+    @Override
+    public String gatherEmails(String prompt) {
+        return addressBook.gatherPersons(prompt);
+    }
+
     //=========== Filtered Person List Accessors =============================================================
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -101,6 +101,10 @@ public class Person {
      */
     public String gatherEmailsContainsFinancialPlan(String prompt) {
         FinancialPlan fp = new FinancialPlan(prompt);
+        /*
+         .contains() method checks if the hashcode of objects in the Hashset
+         and the object passed as argument corresponds.
+         */
         if (financialPlans.contains(fp)) {
             return this.email.toString();
         }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -99,7 +99,7 @@ public class Person {
     /**
      * Checks if the given {@code prompt} is in the {@code financialPlans} and returns the email if true.
      */
-    public String compareFinancialPlan(String prompt) {
+    public String gatherEmailsContainsFinancialPlan(String prompt) {
         FinancialPlan fp = new FinancialPlan(prompt);
         if (financialPlans.contains(fp)) {
             return this.email.toString();

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -97,6 +97,17 @@ public class Person {
     }
 
     /**
+     * Checks if the given {@code prompt} is in the {@code financialPlans} and returns the email if true.
+     */
+    public String compareFinancialPlan(String prompt) {
+        FinancialPlan fp = new FinancialPlan(prompt);
+        if (financialPlans.contains(fp)) {
+            return this.email.toString();
+        }
+        return new String();
+    }
+
+    /**
      * Returns true if both persons have the same identity and data fields.
      * This defines a stronger notion of equality between two persons.
      */

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -104,7 +104,7 @@ public class UniquePersonList implements Iterable<Person> {
         StringBuilder emails = new StringBuilder();
 
         for (Person person : internalList) {
-            String email = person.compareFinancialPlan(prompt);
+            String email = person.gatherEmailsContainsFinancialPlan(prompt);
             if (!email.isEmpty()) {
                 emails.append(email).append(" ");
             }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -98,6 +98,22 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
+     * Gathers the persons emails with {@code prompt} from this {@code persons}.
+     */
+    public String gatherEmails(String prompt) {
+        StringBuilder emails = new StringBuilder();
+
+        for (Person person : internalList) {
+            String email = person.compareFinancialPlan(prompt);
+            if (!email.isEmpty()) {
+                emails.append(email).append(" ");
+            }
+        }
+
+        return emails.toString().trim();
+    };
+
+    /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */
     public ObservableList<Person> asUnmodifiableObservableList() {

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -157,6 +157,11 @@ public class AddCommandTest {
         public void updateFilteredPersonList(Predicate<Person> predicate) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public String gatherEmails(String prompt) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/GatherCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/GatherCommandTest.java
@@ -1,0 +1,73 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.GatherCommand.MESSAGE_NO_PERSON_FOUND;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.GEORGE;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code GatherCommand}.
+ */
+public class GatherCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    void execute_gatherEmails_success() {
+        String message = ALICE.getEmail() + " " + BENSON.getEmail() + " " + GEORGE.getEmail();
+        String prompt = "Sample Financial Plan 1";
+        String expectedMessage = expectedModel.gatherEmails(prompt);
+        GatherCommand command = new GatherCommand(prompt);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertCommandSuccess(command, model, message, expectedModel);
+    }
+
+    @Test
+    public void execute_noPersonFound() {
+        String prompt = "Sample Plan 3";
+        String expectedMessage = String.format(MESSAGE_NO_PERSON_FOUND + prompt);
+        GatherCommand command = new GatherCommand(prompt);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    void testEquals() {
+        GatherCommand gatherFirstCommand = new GatherCommand("first");
+        GatherCommand gatherSecondCommand = new GatherCommand("second");
+
+        // same object -> returns true
+        assertTrue(gatherFirstCommand.equals(gatherFirstCommand));
+
+        // same values -> returns true
+        GatherCommand gatherFirstCommandCopy = new GatherCommand("first");
+        assertTrue(gatherFirstCommand.equals(gatherFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(gatherFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(gatherFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(gatherFirstCommand.equals(gatherSecondCommand));
+    }
+
+    @Test
+    void testToString() {
+        String prompt = "prompt";
+        GatherCommand gatherCommand = new GatherCommand(prompt);
+        String expected = GatherCommand.class.getCanonicalName() + "{prompt=" + prompt + "}";
+        assertEquals(expected, gatherCommand.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -20,6 +20,7 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.GatherCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -76,6 +77,14 @@ public class AddressBookParserTest {
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+    }
+
+    @Test
+    public void parseCommand_gather() throws Exception {
+        String prompt = "Sample Prompt";
+        GatherCommand command = (GatherCommand) parser.parseCommand(
+                GatherCommand.COMMAND_WORD + " " + prompt);
+        assertEquals(new GatherCommand(prompt), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/GatherCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/GatherCommandParserTest.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.GatherCommand;
+
+public class GatherCommandParserTest {
+    private GatherCommandParser parser = new GatherCommandParser();
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, GatherCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsGatherCommand() {
+        String prompt = "Sample Prompt";
+        GatherCommand expectedGatherCommand = new GatherCommand(prompt);
+        assertParseSuccess(parser, prompt, expectedGatherCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/GatherCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/GatherCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.GatherCommandParser.MESSAGE_CONSTRAINTS;
 
 import org.junit.jupiter.api.Test;
 
@@ -13,6 +14,12 @@ public class GatherCommandParserTest {
     @Test
     public void parse_emptyArg_throwsParseException() {
         assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, GatherCommand.MESSAGE_USAGE));
+    }
+    @Test
+    public void parse_invalidArgs_returnsException() {
+        String prompt = "***";
+        String exceptionMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, prompt, exceptionMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -60,7 +60,7 @@ public class AddressBookTest {
     public void gather_noPersonFound() {
         addressBook.addPerson(ALICE);
         String prompt = "Sample Financial Plan 3";
-        assertEquals(new String(), addressBook.gatherPersons(prompt));
+        assertEquals(new String(), addressBook.gatherEmails(prompt));
     }
 
     @Test
@@ -68,7 +68,7 @@ public class AddressBookTest {
         addressBook.addPerson(ELLE);
         FinancialPlan elleFinancialPlan = ELLE.getFinancialPlans().iterator().next();
         String prompt = elleFinancialPlan.toString().replaceAll("[\\[\\]\\(\\)]", "");
-        assertEquals(ELLE.getEmail().toString(), addressBook.gatherPersons(prompt));
+        assertEquals(ELLE.getEmail().toString(), addressBook.gatherEmails(prompt));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.financialplan.FinancialPlan;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.testutil.PersonBuilder;
@@ -52,6 +54,21 @@ public class AddressBookTest {
         AddressBookStub newData = new AddressBookStub(newPersons);
 
         assertThrows(DuplicatePersonException.class, () -> addressBook.resetData(newData));
+    }
+
+    @Test
+    public void gather_noPersonFound() {
+        addressBook.addPerson(ALICE);
+        String prompt = "Sample Financial Plan 3";
+        assertEquals(new String(), addressBook.gatherPersons(prompt));
+    }
+
+    @Test
+    public void gather_personFound() {
+        addressBook.addPerson(ELLE);
+        FinancialPlan elleFinancialPlan = ELLE.getFinancialPlans().iterator().next();
+        String prompt = elleFinancialPlan.toString().replaceAll("[\\[\\]\\(\\)]", "");
+        assertEquals(ELLE.getEmail().toString(), addressBook.gatherPersons(prompt));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -7,6 +7,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.ELLE;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -15,6 +16,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.financialplan.FinancialPlan;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.testutil.AddressBookBuilder;
 
@@ -63,6 +65,21 @@ public class ModelManagerTest {
     @Test
     public void setAddressBookFilePath_nullPath_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> modelManager.setAddressBookFilePath(null));
+    }
+
+    @Test
+    public void gatherEmails_noPersonFound() {
+        modelManager.addPerson(ALICE);
+        String prompt = "Sample Financial Plan 3";
+        assertEquals(new String(), modelManager.gatherEmails(prompt));
+    }
+
+    @Test
+    public void gatherEmails_personFound() {
+        modelManager.addPerson(ELLE);
+        FinancialPlan elleFinancialPlan = ELLE.getFinancialPlans().iterator().next();
+        String prompt = elleFinancialPlan.toString().replaceAll("[\\[\\]\\(\\)]", "");
+        assertEquals(ELLE.getEmail().toString(), modelManager.gatherEmails(prompt));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -13,9 +13,11 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
+import static seedu.address.testutil.TypicalPersons.ELLE;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.financialplan.FinancialPlan;
 import seedu.address.testutil.PersonBuilder;
 
 public class PersonTest {
@@ -99,6 +101,21 @@ public class PersonTest {
         // different tags -> returns false
         editedAlice = new PersonBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();
         assertFalse(ALICE.equals(editedAlice));
+    }
+
+    @Test
+    public void gatherEmails_noPersonFound() {
+        String prompt = "Sample Financial Plan 3";
+        assertEquals(new String(), ALICE.compareFinancialPlan(prompt));
+    }
+
+    @Test
+    public void gatherEmails_personFound() {
+        FinancialPlan elleFinancialPlan = ELLE.getFinancialPlans().iterator().next();
+        String prompt = elleFinancialPlan.toString().replaceAll("[\\[\\]\\(\\)]", "");
+        String prompt2 = "Sample Financial Plan 2";
+        assertEquals(ELLE.getEmail().toString(), ELLE.compareFinancialPlan(prompt));
+        assertEquals(ELLE.getEmail().toString(), ELLE.compareFinancialPlan(prompt2));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -106,7 +106,7 @@ public class PersonTest {
     @Test
     public void gatherEmails_noPersonFound() {
         String prompt = "Sample Financial Plan 3";
-        assertEquals(new String(), ALICE.compareFinancialPlan(prompt));
+        assertEquals(new String(), ALICE.gatherEmailsContainsFinancialPlan(prompt));
     }
 
     @Test
@@ -114,8 +114,8 @@ public class PersonTest {
         FinancialPlan elleFinancialPlan = ELLE.getFinancialPlans().iterator().next();
         String prompt = elleFinancialPlan.toString().replaceAll("[\\[\\]\\(\\)]", "");
         String prompt2 = "Sample Financial Plan 2";
-        assertEquals(ELLE.getEmail().toString(), ELLE.compareFinancialPlan(prompt));
-        assertEquals(ELLE.getEmail().toString(), ELLE.compareFinancialPlan(prompt2));
+        assertEquals(ELLE.getEmail().toString(), ELLE.gatherEmailsContainsFinancialPlan(prompt));
+        assertEquals(ELLE.getEmail().toString(), ELLE.gatherEmailsContainsFinancialPlan(prompt2));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
+import static seedu.address.testutil.TypicalPersons.ELLE;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -15,6 +16,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.financialplan.FinancialPlan;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.testutil.PersonBuilder;
@@ -160,6 +162,21 @@ public class UniquePersonListTest {
     public void setPersons_listWithDuplicatePersons_throwsDuplicatePersonException() {
         List<Person> listWithDuplicatePersons = Arrays.asList(ALICE, ALICE);
         assertThrows(DuplicatePersonException.class, () -> uniquePersonList.setPersons(listWithDuplicatePersons));
+    }
+
+    @Test
+    public void gatherEmails_noPersonFound() {
+        uniquePersonList.add(ALICE);
+        String prompt = "Sample Financial Plan 3";
+        assertEquals(new String(), uniquePersonList.gatherEmails(prompt));
+    }
+
+    @Test
+    public void gatherEmails_personFound() {
+        uniquePersonList.add(ELLE);
+        FinancialPlan elleFinancialPlan = ELLE.getFinancialPlans().iterator().next();
+        String prompt = elleFinancialPlan.toString().replaceAll("[\\[\\]\\(\\)]", "");
+        assertEquals(ELLE.getEmail().toString(), uniquePersonList.gatherEmails(prompt));
     }
 
     @Test


### PR DESCRIPTION
Gather command: users can key in a `gather PROMPT` command to gather all the emails of persons with the `PROMPT` financial plan. Passes a string prompt to the Person Class to compare.

future enhancement: Can implement other ways to gather emails like tags. 