### PR TITLE
Bug fixes for Schedule Command. Add Testing for Appointment and Schedule command. 

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ScheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ScheduleCommand.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_DATE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
@@ -19,9 +21,14 @@ public class ScheduleCommand extends Command {
 
     public static final String COMMAND_WORD = "schedule";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Schedules an appointment for"
-            + "by the index number used in the displayed person list";
-
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Schedules an appointment of the person identified "
+            + "by the index number used in the displayed person list. "
+            + "Parameters: INDEX(must be a positive integer) "
+            + "[" + PREFIX_APPOINTMENT + "Appointment Name] "
+            + "[" + PREFIX_APPOINTMENT_DATE + "Appointment Date] "
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_APPOINTMENT + "Review Insurance "
+            + PREFIX_APPOINTMENT_DATE + "01-01-2023 20:00";
     public static final String MESSAGE_SCHEDULE_SUCCESS = "New appointment added: %1$s";
     private final Index index;
     private final Appointment toAdd;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -158,29 +158,38 @@ public class ParserUtil {
     /**
      * Parses a {@code String aptName} and {@code String aptDateString} into an {@code Appointment}.
      *
-     * @param aptName The name of the appointment.
-     * @param aptDateString The appointment date and time.
+     * @param appointmentName The name of the appointment.
+     * @param appointmentDateString The appointment date and time.
      * @return The Appointment.
      * @throws ParseException If the given {@code aptName} or {@code aptDateString}.
      */
-    public static Appointment parseAppointment(String aptName, String aptDateString) throws ParseException {
-        requireNonNull(aptName);
-        requireNonNull(aptDateString);
+    public static Appointment parseAppointment(String appointmentName, String appointmentDateString)
+            throws ParseException {
+        requireNonNull(appointmentName);
+        requireNonNull(appointmentDateString);
 
-        String trimmedAptName = aptName.trim();
+        String trimmedAppointmentName = appointmentName.trim();
 
-        if (!Appointment.isValidDate(aptDateString)) {
-            throw new ParseException(Appointment.MESSAGE_CONSTRAINTS);
+//        if (trimmedAppointmentName.equals("")) {
+//            throw new ParseException(Appointment.MESSAGE_DESC_CONSTRAINTS);
+//        }
+
+        if (!Appointment.isValidDesc(appointmentName)) {
+            throw new ParseException(Appointment.MESSAGE_DESC_CONSTRAINTS);
         }
 
-        LocalDateTime aptDate;
-        try {
-            aptDate = Appointment.parseAppointmentDate(aptDateString);
-        } catch (IllegalArgumentException e) {
+        if (!Appointment.isValidDate(appointmentDateString)) {
             throw new ParseException(Appointment.MESSAGE_DATE_CONSTRAINTS);
         }
 
-        return new Appointment(trimmedAptName, aptDate);
+        LocalDateTime appointmentDate;
+        try {
+            appointmentDate = Appointment.parseAppointmentDate(appointmentDateString);
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(Appointment.MESSAGE_INVALID_DATE);
+        }
+
+        return new Appointment(trimmedAppointmentName, appointmentDate);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -170,22 +171,18 @@ public class ParserUtil {
 
         String trimmedAppointmentName = appointmentName.trim();
 
-//        if (trimmedAppointmentName.equals("")) {
-//            throw new ParseException(Appointment.MESSAGE_DESC_CONSTRAINTS);
-//        }
-
         if (!Appointment.isValidDesc(appointmentName)) {
             throw new ParseException(Appointment.MESSAGE_DESC_CONSTRAINTS);
         }
 
-        if (!Appointment.isValidDate(appointmentDateString)) {
+        if (!Appointment.isValidDateFormat(appointmentDateString)) {
             throw new ParseException(Appointment.MESSAGE_DATE_CONSTRAINTS);
         }
 
         LocalDateTime appointmentDate;
         try {
             appointmentDate = Appointment.parseAppointmentDate(appointmentDateString);
-        } catch (IllegalArgumentException e) {
+        } catch (DateTimeParseException e) {
             throw new ParseException(Appointment.MESSAGE_INVALID_DATE);
         }
 

--- a/src/main/java/seedu/address/logic/parser/ScheduleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ScheduleCommandParser.java
@@ -2,11 +2,18 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEXT_OF_KIN_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEXT_OF_KIN_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.ParserUtil.parseAppointment;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ScheduleCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.appointment.Appointment;
@@ -27,17 +34,24 @@ public class ScheduleCommandParser implements Parser<ScheduleCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_APPOINTMENT, PREFIX_APPOINTMENT_DATE);
 
+        if (!arePrefixesPresent(argMultimap, PREFIX_APPOINTMENT, PREFIX_APPOINTMENT_DATE) {
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        }
+
         Index index;
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ScheduleCommand.MESSAGE_USAGE), pe);
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_APPOINTMENT, PREFIX_APPOINTMENT_DATE);
-        Appointment appointment = ParserUtil.parseAppointment(argMultimap.getValue(PREFIX_APPOINTMENT).get(),
+        Appointment appointment = parseAppointment(argMultimap.getValue(PREFIX_APPOINTMENT).get(),
                 argMultimap.getValue(PREFIX_APPOINTMENT_DATE).get());
 
         return new ScheduleCommand(index, appointment);
     }
+
+    public
 }

--- a/src/main/java/seedu/address/logic/parser/ScheduleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ScheduleCommandParser.java
@@ -2,18 +2,13 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_DATE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NEXT_OF_KIN_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NEXT_OF_KIN_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.ParserUtil.parseAppointment;
 
+import java.util.stream.Stream;
+
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ScheduleCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.appointment.Appointment;
@@ -34,9 +29,9 @@ public class ScheduleCommandParser implements Parser<ScheduleCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_APPOINTMENT, PREFIX_APPOINTMENT_DATE);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_APPOINTMENT, PREFIX_APPOINTMENT_DATE) {
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        if (!arePrefixesPresent(argMultimap, PREFIX_APPOINTMENT, PREFIX_APPOINTMENT_DATE)
+                || argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ScheduleCommand.MESSAGE_USAGE));
         }
 
         Index index;
@@ -46,6 +41,8 @@ public class ScheduleCommandParser implements Parser<ScheduleCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ScheduleCommand.MESSAGE_USAGE), pe);
         }
 
+
+
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_APPOINTMENT, PREFIX_APPOINTMENT_DATE);
         Appointment appointment = parseAppointment(argMultimap.getValue(PREFIX_APPOINTMENT).get(),
                 argMultimap.getValue(PREFIX_APPOINTMENT_DATE).get());
@@ -53,5 +50,7 @@ public class ScheduleCommandParser implements Parser<ScheduleCommand> {
         return new ScheduleCommand(index, appointment);
     }
 
-    public
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
 }

--- a/src/main/java/seedu/address/model/appointment/Appointment.java
+++ b/src/main/java/seedu/address/model/appointment/Appointment.java
@@ -13,12 +13,15 @@ import java.util.regex.Pattern;
  * Represents an Appointment in the address book.
  */
 public class Appointment {
-    public static final String MESSAGE_CONSTRAINTS = "Input Date should be in format of dd-MM-yyyy HH:mm";
-    public static final String MESSAGE_DATE_CONSTRAINTS = "Invalid date or time given";
+    public static final String MESSAGE_DATE_CONSTRAINTS = "Input Date should be in format of dd-MM-yyyy HH:mm";
+    public static final String MESSAGE_INVALID_DATE = "Please ensure you input a valid date and time";
+    public static final String MESSAGE_DESC_CONSTRAINTS = "Appointment description should only contain alphanumeric "
+            + "characters and spaces, and it should not be blank";
     public static final String MESSAGE_APT_CONSTRAINTS = "Invalid appointment string. "
             + "Should be (description), (date) (time)";
     public static final String VALIDATION_DATE_REGEX = "\\d{2}-\\d{2}-\\d{4} \\d{2}:\\d{2}";
-    public static final String VALIDATION_APT_REGEX = "^(.*), (\\d{2}-\\d{2}-\\d{4} \\d{2}:\\d{2})$";
+    public static final String VALIDATION_DESC_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_APT_REGEX = "^([\\p{Alnum}][\\p{Alnum} ]*), (\\d{2}-\\d{2}-\\d{4} \\d{2}:\\d{2})$";
     public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");
 
     public final String value;
@@ -60,11 +63,12 @@ public class Appointment {
     public int hashCode() {
         return Objects.hash(value, date);
     }
-
+    public static boolean isValidDesc(String desc) {
+        return desc.matches(VALIDATION_DESC_REGEX);
+    }
     public static boolean isValidDate(String date) {
         return date.matches(VALIDATION_DATE_REGEX);
     }
-
     public static boolean isValidAppointment(String appointment) {
         return appointment.matches(VALIDATION_APT_REGEX);
     }

--- a/src/main/java/seedu/address/model/appointment/Appointment.java
+++ b/src/main/java/seedu/address/model/appointment/Appointment.java
@@ -1,5 +1,7 @@
 package seedu.address.model.appointment;
 
+import static java.util.Objects.requireNonNull;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Objects;
@@ -29,6 +31,7 @@ public class Appointment {
      * @param date A valid LocalDateTime object representing Appointment date.
      */
     public Appointment(String value, LocalDateTime date) {
+        requireNonNull(value);
         this.value = value;
         this.date = date;
     }

--- a/src/main/java/seedu/address/model/appointment/Appointment.java
+++ b/src/main/java/seedu/address/model/appointment/Appointment.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Objects;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -21,7 +22,8 @@ public class Appointment {
             + "Should be (description), (date) (time)";
     public static final String VALIDATION_DATE_REGEX = "\\d{2}-\\d{2}-\\d{4} \\d{2}:\\d{2}";
     public static final String VALIDATION_DESC_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
-    public static final String VALIDATION_APT_REGEX = "^([\\p{Alnum}][\\p{Alnum} ]*), (\\d{2}-\\d{2}-\\d{4} \\d{2}:\\d{2})$";
+    public static final String VALIDATION_APT_REGEX = "^([\\p{Alnum}][\\p{Alnum} ]*), "
+            + "(\\d{2}-\\d{2}-\\d{4} \\d{2}:\\d{2})$";
     public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");
 
     public final String value;
@@ -63,13 +65,28 @@ public class Appointment {
     public int hashCode() {
         return Objects.hash(value, date);
     }
+
+    /**
+     * Returns true if given string is valid appointment description.
+     */
     public static boolean isValidDesc(String desc) {
+        requireNonNull(desc);
         return desc.matches(VALIDATION_DESC_REGEX);
     }
-    public static boolean isValidDate(String date) {
+
+    /**
+     * Returns true if given string is valid date time.
+     */
+    public static boolean isValidDateFormat(String date) {
+        requireNonNull(date);
         return date.matches(VALIDATION_DATE_REGEX);
     }
+
+    /**
+     * Returns true if given string is valid appointment.
+     */
     public static boolean isValidAppointment(String appointment) {
+        requireNonNull(appointment);
         return appointment.matches(VALIDATION_APT_REGEX);
     }
 
@@ -80,7 +97,7 @@ public class Appointment {
      * @return The LocaleDateTime object representing Appointment date.
      * @throws IllegalArgumentException If input date does not match specified format.
      */
-    public static LocalDateTime parseAppointmentDate(String input) throws IllegalArgumentException {
+    public static LocalDateTime parseAppointmentDate(String input) throws DateTimeParseException {
         return LocalDateTime.parse(input, DATE_FORMATTER);
     }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -41,13 +41,13 @@ public class CommandTestUtil {
     public static final String VALID_NEXT_OF_KIN_NAME_BOB = "Bob Dad";
     public static final String VALID_NEXT_OF_KIN_PHONE_AMY = "33333333";
     public static final String VALID_NEXT_OF_KIN_PHONE_BOB = "44444444";
-
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
-
     public static final String VALID_FINANCIAL_PLAN_1 = "financial plan 1";
     public static final String VALID_FINANCIAL_PLAN_2 = "financial plan 2";
-
+    public static final String VALID_APPOINTMENT_NAME = "Review Insurance";
+    public static final String VALID_APPOINTMENT_DATE = "01-01-2023 20:00";
+    public static final String VALID_APPOINTMENT = VALID_APPOINTMENT_NAME + ", " + VALID_APPOINTMENT_DATE;
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
     public static final String PHONE_DESC_AMY = " " + PREFIX_PHONE + VALID_PHONE_AMY;
@@ -69,7 +69,6 @@ public class CommandTestUtil {
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
     public static final String FINANCIAL_PLAN_DESC_1 = " " + PREFIX_FINANCIAL_PLAN + VALID_FINANCIAL_PLAN_1;
     public static final String FINANCIAL_PLAN_DESC_2 = " " + PREFIX_FINANCIAL_PLAN + VALID_FINANCIAL_PLAN_2;
-
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
@@ -81,7 +80,8 @@ public class CommandTestUtil {
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
     public static final String INVALID_FINANCIAL_PLAN_DESC = " " + PREFIX_FINANCIAL_PLAN
             + "financial_plan"; // '_' not allowed in financial plan names
-
+    public static final String INVALID_APPOINTMENT_TIME_FORMAT = "01-01-2023 12pm";
+    public static final String INVALID_APPOINTMENT_DATE_FORMAT = "1 Jan 2023 18:00";
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -3,6 +3,8 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FINANCIAL_PLAN;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -69,6 +71,8 @@ public class CommandTestUtil {
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
     public static final String FINANCIAL_PLAN_DESC_1 = " " + PREFIX_FINANCIAL_PLAN + VALID_FINANCIAL_PLAN_1;
     public static final String FINANCIAL_PLAN_DESC_2 = " " + PREFIX_FINANCIAL_PLAN + VALID_FINANCIAL_PLAN_2;
+    public static final String APPOINTMENT_NAME_DESC = " " + PREFIX_APPOINTMENT + VALID_APPOINTMENT_NAME;
+    public static final String APPOINTMENT_DATE_DESC = " " + PREFIX_APPOINTMENT_DATE + VALID_APPOINTMENT_DATE;
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
@@ -80,8 +84,10 @@ public class CommandTestUtil {
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
     public static final String INVALID_FINANCIAL_PLAN_DESC = " " + PREFIX_FINANCIAL_PLAN
             + "financial_plan"; // '_' not allowed in financial plan names
-    public static final String INVALID_APPOINTMENT_TIME_FORMAT = "01-01-2023 12pm";
-    public static final String INVALID_APPOINTMENT_DATE_FORMAT = "1 Jan 2023 18:00";
+    public static final String INVALID_APPOINTMENT_NAME_DESC = " " + PREFIX_APPOINTMENT + "Review *&Insurance";
+    public static final String INVALID_APPOINTMENT_TIME_FORMAT = " " + PREFIX_APPOINTMENT_DATE + "01-01-2023 12pm";
+    public static final String INVALID_APPOINTMENT_DATE_FORMAT = " " + PREFIX_APPOINTMENT_DATE + "1 Jan 2023 18:00";
+    public static final String INVALID_APPOINTMENT_DATE = " " + PREFIX_APPOINTMENT_DATE + "10-13-2023 00:00";
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 

--- a/src/test/java/seedu/address/logic/commands/ScheduleCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ScheduleCommandTest.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.appointment.Appointment;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+class ScheduleCommandTest {
+    private static final String APPOINTMENT_DESCRIPTION_STUB = "Review Insurance, 01-01-2023 20:00";
+    private static final Appointment APPOINTMENT_STUB = Appointment.parseAppointmentDescription(
+            APPOINTMENT_DESCRIPTION_STUB);
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    @Test
+    public void execute_scheduleAccepted_scheduleSuccessful() {
+        Person personWithoutSchedule = model.getFilteredPersonList().get(0);
+
+        ScheduleCommand scheduleCommand = new ScheduleCommand(INDEX_FIRST_PERSON, APPOINTMENT_STUB);
+        Person personWithSchedule = new PersonBuilder(personWithoutSchedule)
+                .withAppointment(APPOINTMENT_DESCRIPTION_STUB).build();
+
+        String expectedMessage = String.format(ScheduleCommand.MESSAGE_SCHEDULE_SUCCESS,
+                Messages.format(personWithSchedule));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(0), personWithSchedule);
+
+        assertCommandSuccess(scheduleCommand, model, expectedMessage, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -14,6 +15,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.appointment.Appointment;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -26,16 +28,18 @@ public class ParserUtilTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
-
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
-
+    private static final String VALID_APPOINTMENT_DESC = "Review Insurance";
+    private static final String VALID_APPOINTMENT_DATE = "01-01-2023 20:00";
     private static final String WHITESPACE = " \t\r\n";
-
+    private static final String INVALID_APPOINTMENT_DESC = "#Review Insurance*";
+    private static final String INVALID_APPOINTMENT_DATE_FORMAT = "1 May 2023 20:00";
+    private static final String INVALID_APPOINTMENT_DATE = "01-13-2023 20:00";
     @Test
     public void parseIndex_invalidInput_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseIndex("10 a"));
@@ -192,5 +196,30 @@ public class ParserUtilTest {
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseAppointment_validValueAndDate_returnsAppointment() throws Exception {
+        Appointment expectedAppointment = new Appointment("Review Insurance",
+                LocalDateTime.of(2023, 1, 1, 20, 0));
+        assertEquals(expectedAppointment, ParserUtil.parseAppointment(VALID_APPOINTMENT_DESC, VALID_APPOINTMENT_DATE));
+    }
+
+    @Test
+    public void parseAppointment_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseAppointment(null,
+                null));
+    }
+
+    @Test
+    public void parseAppointment_invalidInputs_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseAppointment(INVALID_APPOINTMENT_DESC,
+                VALID_APPOINTMENT_DATE));
+
+        assertThrows(ParseException.class, () -> ParserUtil.parseAppointment(VALID_APPOINTMENT_DESC,
+                INVALID_APPOINTMENT_DATE_FORMAT));
+
+        assertThrows(ParseException.class, () -> ParserUtil.parseAppointment(VALID_APPOINTMENT_DESC,
+                INVALID_APPOINTMENT_DATE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ScheduleCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ScheduleCommandParserTest.java
@@ -1,0 +1,51 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_APPOINTMENT_DATE_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_APPOINTMENT_TIME_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_DATE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_DATE;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.ScheduleCommand;
+import seedu.address.model.appointment.Appointment;
+
+class ScheduleCommandParserTest {
+    private ScheduleCommandParser parser = new ScheduleCommandParser();
+    @Test
+    public void parse_validScheduleInput_success() {
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String userInput = targetIndex.getOneBased() + " "
+                + PREFIX_APPOINTMENT + VALID_APPOINTMENT_NAME + " "
+                + PREFIX_APPOINTMENT_DATE + VALID_APPOINTMENT_DATE;
+
+        LocalDateTime date = Appointment.parseAppointmentDate(VALID_APPOINTMENT_DATE);
+        Appointment appointment = new Appointment(VALID_APPOINTMENT_NAME, date);
+
+        assertParseSuccess(parser, userInput, new ScheduleCommand(targetIndex, appointment));
+    }
+
+    @Test
+    public void parse_invalidDate_failure() {
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String invalidTimeString = targetIndex.getOneBased() + " "
+                + PREFIX_APPOINTMENT + VALID_APPOINTMENT_NAME + " "
+                + PREFIX_APPOINTMENT_DATE + INVALID_APPOINTMENT_TIME_FORMAT;
+
+        assertParseFailure(parser, invalidTimeString, Appointment.MESSAGE_CONSTRAINTS);
+
+        String invalidDateString = targetIndex.getOneBased() + " "
+                + PREFIX_APPOINTMENT + VALID_APPOINTMENT_NAME + " "
+                + PREFIX_APPOINTMENT_DATE + INVALID_APPOINTMENT_DATE_FORMAT;
+
+        assertParseFailure(parser, invalidDateString, Appointment.MESSAGE_CONSTRAINTS);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ScheduleCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ScheduleCommandParserTest.java
@@ -1,6 +1,11 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.APPOINTMENT_DATE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.APPOINTMENT_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_APPOINTMENT_DATE;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_APPOINTMENT_DATE_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_APPOINTMENT_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_APPOINTMENT_TIME_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_DATE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_NAME;
@@ -15,17 +20,17 @@ import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.ScheduleCommand;
 import seedu.address.model.appointment.Appointment;
 
 class ScheduleCommandParserTest {
     private ScheduleCommandParser parser = new ScheduleCommandParser();
+    private Index targetIndex = INDEX_FIRST_PERSON;
+
     @Test
     public void parse_validScheduleInput_success() {
-        Index targetIndex = INDEX_FIRST_PERSON;
-        String userInput = targetIndex.getOneBased() + " "
-                + PREFIX_APPOINTMENT + VALID_APPOINTMENT_NAME + " "
-                + PREFIX_APPOINTMENT_DATE + VALID_APPOINTMENT_DATE;
+        String userInput = targetIndex.getOneBased() + APPOINTMENT_NAME_DESC + APPOINTMENT_DATE_DESC;
 
         LocalDateTime date = Appointment.parseAppointmentDate(VALID_APPOINTMENT_DATE);
         Appointment appointment = new Appointment(VALID_APPOINTMENT_NAME, date);
@@ -34,18 +39,52 @@ class ScheduleCommandParserTest {
     }
 
     @Test
-    public void parse_invalidDate_failure() {
-        Index targetIndex = INDEX_FIRST_PERSON;
-        String invalidTimeString = targetIndex.getOneBased() + " "
-                + PREFIX_APPOINTMENT + VALID_APPOINTMENT_NAME + " "
-                + PREFIX_APPOINTMENT_DATE + INVALID_APPOINTMENT_TIME_FORMAT;
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, ScheduleCommand.MESSAGE_USAGE);
 
-        assertParseFailure(parser, invalidTimeString, Appointment.MESSAGE_CONSTRAINTS);
+        //missing appointment name prefix
+        assertParseFailure(parser, targetIndex.getOneBased() + " " + VALID_APPOINTMENT_NAME
+                + APPOINTMENT_DATE_DESC, expectedMessage);
 
-        String invalidDateString = targetIndex.getOneBased() + " "
-                + PREFIX_APPOINTMENT + VALID_APPOINTMENT_NAME + " "
-                + PREFIX_APPOINTMENT_DATE + INVALID_APPOINTMENT_DATE_FORMAT;
+        //missing appointment date prefix
+        assertParseFailure(parser, targetIndex.getOneBased() + APPOINTMENT_NAME_DESC
+                + " " + VALID_APPOINTMENT_DATE, expectedMessage);
 
-        assertParseFailure(parser, invalidDateString, Appointment.MESSAGE_CONSTRAINTS);
+        //missing index
+        assertParseFailure(parser, APPOINTMENT_NAME_DESC + APPOINTMENT_DATE_DESC, expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+
+        // invalid appointment name
+        String invalidNameString = targetIndex.getOneBased() + INVALID_APPOINTMENT_NAME_DESC
+                + APPOINTMENT_DATE_DESC;
+        assertParseFailure(parser, invalidNameString, Appointment.MESSAGE_DESC_CONSTRAINTS);
+
+        // invalid time format
+        String invalidTimeFormatString = targetIndex.getOneBased() + APPOINTMENT_NAME_DESC
+                + INVALID_APPOINTMENT_TIME_FORMAT;
+        assertParseFailure(parser, invalidTimeFormatString, Appointment.MESSAGE_DATE_CONSTRAINTS);
+
+        // invalid date format
+        String invalidDateFormatString = targetIndex.getOneBased() + APPOINTMENT_NAME_DESC
+                + INVALID_APPOINTMENT_DATE_FORMAT;
+        assertParseFailure(parser, invalidDateFormatString, Appointment.MESSAGE_DATE_CONSTRAINTS);
+
+        // invalid date
+        String invalidDateString = targetIndex.getOneBased() + APPOINTMENT_NAME_DESC + INVALID_APPOINTMENT_DATE;
+        assertParseFailure(parser, invalidDateString, Appointment.MESSAGE_INVALID_DATE);
+
+        // duplicate name
+        String validExpectedSchedule = APPOINTMENT_NAME_DESC + APPOINTMENT_DATE_DESC;
+        assertParseFailure(parser, targetIndex.getOneBased() + " " + PREFIX_APPOINTMENT
+                + VALID_APPOINTMENT_NAME + validExpectedSchedule,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_APPOINTMENT));
+
+        // duplicate date
+        assertParseFailure(parser, targetIndex.getOneBased() + validExpectedSchedule + " "
+                + PREFIX_APPOINTMENT_DATE + VALID_APPOINTMENT_DATE,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_APPOINTMENT_DATE));
     }
 }

--- a/src/test/java/seedu/address/model/appointment/AppointmentTest.java
+++ b/src/test/java/seedu/address/model/appointment/AppointmentTest.java
@@ -1,0 +1,15 @@
+package seedu.address.model.appointment;
+
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+
+class AppointmentTest {
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Appointment(null,
+                LocalDateTime.of(2023, 1, 1, 1, 1)));
+    }
+}

--- a/src/test/java/seedu/address/model/appointment/AppointmentTest.java
+++ b/src/test/java/seedu/address/model/appointment/AppointmentTest.java
@@ -12,4 +12,10 @@ class AppointmentTest {
         assertThrows(NullPointerException.class, () -> new Appointment(null,
                 LocalDateTime.of(2023, 1, 1, 1, 1)));
     }
+
+    @Test
+    public void isValidAppointment() {
+
+    }
+
 }

--- a/src/test/java/seedu/address/model/appointment/AppointmentTest.java
+++ b/src/test/java/seedu/address/model/appointment/AppointmentTest.java
@@ -1,12 +1,20 @@
 package seedu.address.model.appointment;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.person.Name;
+
 class AppointmentTest {
+
+    public static final LocalDateTime VALID_DATE_TIME = LocalDateTime.of(2023, 1, 1, 20, 0);
     @Test
     public void constructor_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new Appointment(null,
@@ -14,8 +22,108 @@ class AppointmentTest {
     }
 
     @Test
-    public void isValidAppointment() {
+    public void isValidDesc() {
+        // null name
+        assertThrows(NullPointerException.class, () -> Appointment.isValidDesc(null));
 
+        // invalid Appointment name
+        assertFalse(Name.isValidName("")); // empty string
+        assertFalse(Name.isValidName(" ")); // spaces only
+        assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
+        assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+
+        // valid Appointment name
+        assertTrue(Name.isValidName("insurance")); // alphabets only
+        assertTrue(Name.isValidName("12345")); // numbers only
+        assertTrue(Name.isValidName("review Insurance 1")); // alphanumeric characters
+        assertTrue(Name.isValidName("Review Insurance")); // with capital letters
+        assertTrue(Name.isValidName("Review Insurance policy 1")); // long names
     }
 
+    @Test
+    public void isValidDateFormat() {
+        // null date
+        assertThrows(NullPointerException.class, () -> Appointment.isValidDateFormat(null));
+
+        // valid date
+        assertTrue(Appointment.isValidDateFormat("01-01-2023 20:00"));
+    }
+
+    @Test
+    public void isValidAppointment() {
+        // null appointment string representation
+        assertThrows(NullPointerException.class, () -> Appointment.isValidAppointment(null));
+
+        // invalid appointment string format
+        assertFalse(Appointment.isValidAppointment("Review Insurance 01-01-2023 20:00"));
+        assertFalse(Appointment.isValidAppointment("Review Insurance, ")); // missing date
+        assertFalse(Appointment.isValidAppointment("01-01-2023 20:00")); // missing name
+        assertFalse(Appointment.isValidAppointment("Review Insurance 01-01-2023 20:00")); // wrong format
+        assertFalse(Appointment.isValidAppointment("Review Insurance 1 May 2023 20:00")); // wrong date
+        assertFalse(Appointment.isValidAppointment("Review Insurance 01-01-2023 8pm")); // wrong time
+        // valid appointment string
+        assertTrue(Appointment.isValidAppointment("Review Insurance, 01-01-2023 20:00"));
+    }
+
+    @Test
+    public void testToStringReturnsExpectedString() {
+        Appointment appointment = new Appointment("Review Insurance",
+                VALID_DATE_TIME);
+
+        // correct string
+        assertEquals(appointment.toString(), "Review Insurance, 01-01-2023 20:00");
+    }
+
+    @Test
+    public void equals() {
+        Appointment appointment = new Appointment("Review Insurance",
+                LocalDateTime.of(2023, 1, 1, 20, 0));
+
+        // same values
+        assertTrue(appointment.equals(new Appointment("Review Insurance",
+                VALID_DATE_TIME)));
+
+        // same object
+        assertTrue(appointment.equals(appointment));
+
+        // null -> returns false
+        assertFalse(appointment.equals(null));
+
+        // different types -> returns false
+        assertFalse(appointment.equals(5.0f));
+
+        // different name values -> returns false
+        assertFalse(appointment.equals(new Appointment("Insurance nomination",
+                LocalDateTime.of(2023, 1, 1, 20, 0))));
+
+        // different date obj -> returns false
+        assertFalse(appointment.equals(new Appointment("Review insurance",
+                LocalDateTime.of(2023, 5, 2, 18, 0))));
+    }
+    @Test
+    public void parseAppointmentDate() {
+        LocalDateTime expectedDateTime = VALID_DATE_TIME;
+
+        assertEquals(expectedDateTime, Appointment.parseAppointmentDate("01-01-2023 20:00"));
+
+        // invalid day
+        assertThrows(DateTimeParseException.class, () -> Appointment.parseAppointmentDate("32-01-2023 20:00"));
+        // invalid month
+        assertThrows(DateTimeParseException.class, () -> Appointment.parseAppointmentDate("01-13-2023 20:00"));
+        // invalid year
+        assertThrows(DateTimeParseException.class, () -> Appointment.parseAppointmentDate("01-13-0100 20:00"));
+        // invalid hours
+        assertThrows(DateTimeParseException.class, () -> Appointment.parseAppointmentDate("01-01-2023 25:00"));
+        // invalid minutes
+        assertThrows(DateTimeParseException.class, () -> Appointment.parseAppointmentDate("01-01-2023 20:61"));
+    }
+    @Test
+    public void parseAppointmentDescription() {
+        Appointment expectedAppointment = new Appointment("Review Insurance",
+                VALID_DATE_TIME);
+
+        Appointment testAppointment = Appointment.parseAppointmentDescription("Review Insurance, 01-01-2023 20:00");
+
+        assertEquals(expectedAppointment, testAppointment);
+    }
 }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_DATE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_NAME;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NEXT_OF_KIN_NAME_BOB;
@@ -12,6 +14,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.BOB;
 import static seedu.address.testutil.TypicalPersons.ELLE;
 
@@ -101,6 +104,11 @@ public class PersonTest {
         // different tags -> returns false
         editedAlice = new PersonBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();
         assertFalse(ALICE.equals(editedAlice));
+
+        // different Appointment -> returns false
+        Person editedBenson = new PersonBuilder(BENSON).withAppointment(VALID_APPOINTMENT_NAME
+                + ", " + VALID_APPOINTMENT_DATE).build();
+        assertFalse(BENSON.equals(editedBenson));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.model.appointment.Appointment;
 import seedu.address.model.financialplan.FinancialPlan;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
@@ -43,6 +44,7 @@ public class EditPersonDescriptorBuilder {
         descriptor.setNextOfKinPhone(person.getNextOfKinPhone());
         descriptor.setFinancialPlans(person.getFinancialPlans());
         descriptor.setTags(person.getTags());
+        descriptor.setAppointment(person.getAppointment());
     }
 
     /**
@@ -111,6 +113,16 @@ public class EditPersonDescriptorBuilder {
     public EditPersonDescriptorBuilder withTags(String... tags) {
         Set<Tag> tagSet = Stream.of(tags).map(Tag::new).collect(Collectors.toSet());
         descriptor.setTags(tagSet);
+        return this;
+    }
+
+    /**
+     * Parses the {@code appointmentDesc} into a {@code Appointment} and set it to the {@code EditPersonDescriptor}
+     * that we are building.
+     */
+    public EditPersonDescriptorBuilder withAppointment(String appointmentDesc) {
+        Appointment appointment = Appointment.parseAppointmentDescription(appointmentDesc);
+        descriptor.setAppointment(appointment);
         return this;
     }
 


### PR DESCRIPTION
Fix bugs with regards to schedule command. Add testing for Appointment and Schedule command.

Previously the schedule command has bugs when no prefixes were input and invalid inputs were given. Appointment field and schedule command parsers did not have testing.

Include checks for schedule command for compulsory prefixes and checks for inputs by users. Testing was included for the schedule command and parsers. Testing included for appointment field. 

Resolves #89 #82