### PR TITLE
Add prompt for updating appointment 

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -5,6 +5,8 @@ import static java.util.Objects.requireNonNull;
 import java.util.Objects;
 
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.appointment.Appointment;
+import seedu.address.model.person.Person;
 
 /**
  * Represents the result of a command execution.
@@ -20,6 +22,12 @@ public class CommandResult {
     private final boolean exit;
     /** Confirmation for clear command should be requested. */
     private final boolean showClear;
+    /** Confirmation for overriding command should be requested. */
+    private final boolean showOverride;
+    /** Appointment that will be replaced **/
+    private Appointment appointment = null;
+    /** Person who's appointment will be replaced **/
+    private Person personToEdit = null;
 
     /**
      * Constructs a {@code CommandResult} with the specified fields, with showClear set to false.
@@ -29,6 +37,7 @@ public class CommandResult {
         this.showHelp = showHelp;
         this.exit = exit;
         this.showClear = false;
+        this.showOverride = false;
     }
 
     /**
@@ -39,6 +48,21 @@ public class CommandResult {
         this.showHelp = showHelp;
         this.exit = exit;
         this.showClear = showClear;
+        this.showOverride = false;
+    }
+
+    /**
+     * Constructs a {@code CommandResult} with the specified fields.
+     */
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, boolean showOverride,
+                         Person personToEdit, Appointment appointment) {
+        this.feedbackToUser = requireNonNull(feedbackToUser);
+        this.showHelp = showHelp;
+        this.exit = exit;
+        this.showOverride = showOverride;
+        this.showClear = false;
+        this.personToEdit = personToEdit;
+        this.appointment = appointment;
     }
 
     /**
@@ -63,7 +87,9 @@ public class CommandResult {
     public boolean isShowClear() {
         return showClear;
     }
-
+    public boolean isShowOverride() {
+        return showOverride;
+    }
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -97,4 +123,11 @@ public class CommandResult {
                 .toString();
     }
 
+    public Appointment getAppointment() {
+        return this.appointment;
+    }
+
+    public Person getPersonToEdit() {
+        return this.personToEdit;
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/ConfirmOverrideCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ConfirmOverrideCommand.java
@@ -1,0 +1,53 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.appointment.Appointment;
+import seedu.address.model.person.Person;
+
+/** Overrides the current appointment and replaces it with the new appointment after confirmation **/
+public class ConfirmOverrideCommand extends Command {
+    public static final String MESSAGE_SUCCESS = "Appointment updated!";
+    private static Appointment appointment = null;
+    private static Person personToEdit = null;
+
+    /**
+     * Default constructor for a confirm override command
+     * @param appointment new appointment
+     * @param personToEdit person whos old appointment will be replaced by the new appointment
+     */
+    public ConfirmOverrideCommand(Appointment appointment, Person personToEdit) {
+        this.appointment = appointment;
+        this.personToEdit = personToEdit;
+    }
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+
+        Person personWithApt = createPersonWithAppointment(personToEdit);
+
+        assert personWithApt.getAppointment() instanceof Appointment
+                    : "Schedule Command: person should have appointment";
+
+        appointment.setPerson(personWithApt); //sets person to appointment
+
+        model.setPerson(personToEdit, personWithApt);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(personWithApt)));
+    }
+
+    /**
+     * Returns the {@code Person} with the scheduled Appointment.
+     *
+     * @param personToEdit The Person the appointment is scheduled to.
+     * @return The Person with scheduled appointment.
+     */
+    private Person createPersonWithAppointment(Person personToEdit) {
+        return new Person(personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
+                personToEdit.getAddress(), personToEdit.getNextOfKinName(), personToEdit.getNextOfKinPhone(),
+                personToEdit.getFinancialPlans(), personToEdit.getTags(), appointment);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ConfirmOverrideCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ConfirmOverrideCommand.java
@@ -23,6 +23,15 @@ public class ConfirmOverrideCommand extends Command {
         this.appointment = appointment;
         this.personToEdit = personToEdit;
     }
+
+    public static Appointment getAppointment() {
+        return appointment;
+    }
+
+    public static Person getPersonToEdit() {
+        return personToEdit;
+    }
+
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
@@ -37,6 +46,21 @@ public class ConfirmOverrideCommand extends Command {
         model.setPerson(personToEdit, personWithApt);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(personWithApt)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ConfirmOverrideCommand)) {
+            return false;
+        }
+
+        ConfirmOverrideCommand otherOverrideCommand = (ConfirmOverrideCommand) other;
+        return appointment.equals(otherOverrideCommand.appointment);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/ScheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ScheduleCommand.java
@@ -12,6 +12,7 @@ import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.appointment.Appointment;
+import seedu.address.model.appointment.NullAppointment;
 import seedu.address.model.person.Person;
 
 /**
@@ -30,6 +31,7 @@ public class ScheduleCommand extends Command {
             + PREFIX_APPOINTMENT + "Review Insurance "
             + PREFIX_APPOINTMENT_DATE + "01-01-2023 20:00";
     public static final String MESSAGE_SCHEDULE_SUCCESS = "New appointment added: %1$s";
+    public static final String CONFIRM_OVERRIDE_MESSAGE = "Previous appointment found.";
     private final Index index;
     private final Appointment toAdd;
 
@@ -57,16 +59,22 @@ public class ScheduleCommand extends Command {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
-        Person personWithApt = createPersonWithAppointment(personToEdit);
 
-        assert personWithApt.getAppointment() instanceof Appointment
-                : "Schedule Command: person should have appointment";
+        if (personToEdit.getAppointment() instanceof NullAppointment) {
+            Person personWithApt = createPersonWithAppointment(personToEdit);
 
-        toAdd.setPerson(personWithApt); //sets person to appointment
+            assert personWithApt.getAppointment() instanceof Appointment
+                    : "Schedule Command: person should have appointment";
 
-        model.setPerson(personToEdit, personWithApt);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_SCHEDULE_SUCCESS, Messages.format(personWithApt)));
+            toAdd.setPerson(personWithApt); //sets person to appointment
+
+            model.setPerson(personToEdit, personWithApt);
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+            return new CommandResult(String.format(MESSAGE_SCHEDULE_SUCCESS, Messages.format(personWithApt)));
+        } else {
+            return new CommandResult(CONFIRM_OVERRIDE_MESSAGE,
+                    false, false, true, personToEdit, toAdd);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -17,6 +17,8 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.appointment.Appointment;
+import seedu.address.model.person.Person;
 
 /**
  * The Main Window. Provides the basic application layout containing
@@ -37,6 +39,9 @@ public class MainWindow extends UiPart<Stage> {
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
     private ClearWindow clearWindow;
+    private OverrideWindow overrideWindow;
+    private Appointment appointment;
+    private Person personToEdit;
 
     @FXML
     private StackPane commandBoxPlaceholder;
@@ -169,6 +174,19 @@ public class MainWindow extends UiPart<Stage> {
         }
     }
 
+    /**
+     * Opens the override window or focuses on it if it's already opened.
+     */
+    @FXML
+    public void handleOverride(Appointment appointment, Person personToEdit) {
+        overrideWindow = new OverrideWindow(this::executeCommand, appointment, personToEdit);
+        if (!overrideWindow.isShowing()) {
+            overrideWindow.show();
+        } else {
+            overrideWindow.focus();
+        }
+    }
+
     void show() {
         primaryStage.show();
     }
@@ -240,6 +258,11 @@ public class MainWindow extends UiPart<Stage> {
         }
         if (commandResult.isShowClear()) {
             handleClear();
+        }
+        if (commandResult.isShowOverride()) {
+            this.appointment = commandResult.getAppointment();
+            this.personToEdit = commandResult.getPersonToEdit();
+            handleOverride(appointment, personToEdit);
         }
     }
 }

--- a/src/main/java/seedu/address/ui/OverrideWindow.java
+++ b/src/main/java/seedu/address/ui/OverrideWindow.java
@@ -1,0 +1,141 @@
+package seedu.address.ui;
+
+import java.util.logging.Logger;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.ConfirmOverrideCommand;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.appointment.Appointment;
+import seedu.address.model.person.Person;
+
+/**
+ * Controller for the override appointment command confirmation page.
+ */
+public class OverrideWindow extends UiPart<Stage> {
+
+    public static final String CONFIRM_OVERRIDE_MESSAGE = "There is an appointment found under this persons name"
+            + "are you sure you want to override this appointment? \n";
+
+    private static String message;
+    private static Appointment appointment = null;
+    private static Person personToEdit = null;
+
+    private static final Logger logger = LogsCenter.getLogger(OverrideWindow.class);
+    private static final String FXML = "OverrideWindow.fxml";
+    private CommandExecutor commandExecutor;
+
+    @FXML
+    private Label overrideMessage;
+    @FXML
+    private Button overrideButton;
+    @FXML
+    private Button cancelButton;
+
+    /**
+     * Creates a new OverrideWindow.
+     *
+     * @param root Stage to use as the root of the OverrideWindow.
+     */
+    public OverrideWindow(Stage root) {
+        super(FXML, root);
+        root.initStyle(StageStyle.UNDECORATED);
+        root.initModality(Modality.APPLICATION_MODAL);
+        overrideMessage.setText(CONFIRM_OVERRIDE_MESSAGE);
+    }
+
+    /**
+     * Creates a new OverrideWindow.
+     */
+    public OverrideWindow(CommandExecutor commandExecutor, Appointment appointment, Person personToEdit) {
+        this(new Stage());
+        this.commandExecutor = commandExecutor;
+        this.appointment = appointment;
+        this.personToEdit = personToEdit;
+        overrideMessage.setText(CONFIRM_OVERRIDE_MESSAGE + personToEdit.getAppointment().toString());
+    }
+
+    /**
+     * Shows the clear window.
+     * @throws IllegalStateException
+     *     <ul>
+     *         <li>
+     *             if this method is called on a thread other than the JavaFX Application Thread.
+     *         </li>
+     *         <li>
+     *             if this method is called during animation or layout processing.
+     *         </li>
+     *         <li>
+     *             if this method is called on the primary stage.
+     *         </li>
+     *         <li>
+     *             if {@code dialogStage} is already showing.
+     *         </li>
+     *     </ul>
+     */
+    public void show() {
+        logger.fine("Showing confirm override window.");
+        getRoot().show();
+        getRoot().centerOnScreen();
+    }
+
+    /**
+     * Returns true if the override window is currently being shown.
+     */
+    public boolean isShowing() {
+        return getRoot().isShowing();
+    }
+
+    /**
+     * Hides the override window.
+     */
+    public void hide() {
+        getRoot().hide();
+    }
+
+    /**
+     * Focuses on the override window.
+     */
+    public void focus() {
+        getRoot().requestFocus();
+    }
+    /**
+     * Executes changing of the appointment.
+     */
+    @FXML
+    private void confirmOverride() {
+        Command overrideCommand = new ConfirmOverrideCommand(this.appointment, this.personToEdit);
+        try {
+            commandExecutor.execute(overrideCommand);
+        } catch (CommandException e) {
+            // nothing to do in this window if there's an error.
+        }
+        hide();
+    }
+    /**
+     * Cancels the override command.
+     */
+    @FXML
+    private void cancel() {
+        hide();
+    }
+    /**
+     * Represents a function that can execute commands.
+     */
+    @FunctionalInterface
+    public interface CommandExecutor {
+        /**
+         * Executes the command and returns the result.
+         *
+         * @see seedu.address.logic.Logic#execute(Command)
+         */
+        CommandResult execute(Command command) throws CommandException;
+    }
+}

--- a/src/main/resources/view/OverrideWindow.fxml
+++ b/src/main/resources/view/OverrideWindow.fxml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.net.URL?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.Scene?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.stage.Stage?>
+
+<fx:root resizable="false" title="" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+    <scene>
+        <Scene>
+            <stylesheets>
+                <URL value="@ClearWindow.css" />
+            </stylesheets>
+
+            <HBox alignment="CENTER" fx:id="clearMessageContainer">
+                <children>
+                    <Label fx:id="overrideMessage" text="Label">
+                        <HBox.margin>
+                            <Insets right="5.0" />
+                        </HBox.margin>
+                    </Label>
+                    <Button fx:id="overrideButton" mnemonicParsing="false" onAction="#confirmOverride" text="Override">
+                        <HBox.margin>
+                            <Insets left="5.0" />
+                        </HBox.margin>
+                    </Button>
+                    <Button fx:id="cancelButton" mnemonicParsing="false" onAction="#cancel" text="Cancel">
+                        <HBox.margin>
+                            <Insets left="5.0" />
+                        </HBox.margin>
+                    </Button>
+                </children>
+                <opaqueInsets>
+                    <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
+                </opaqueInsets>
+                <padding>
+                    <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
+                </padding>
+            </HBox>
+        </Scene>
+    </scene>
+</fx:root>

--- a/src/test/java/seedu/address/logic/commands/ConfirmOverrideCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ConfirmOverrideCommandTest.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.appointment.Appointment;
+import seedu.address.model.person.Person;
+
+public class ConfirmOverrideCommandTest {
+
+    private static final String APPOINTMENT_DESCRIPTION_STUB = "Review Insurance, 01-01-2023 20:00";
+
+    @Test
+    public void execute_overridingAppointment_success() {
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+        Person updatedPerson = expectedModel.getFilteredPersonList().get(1);
+        Person personToEdit = model.getFilteredPersonList().get(1);
+        Appointment newAppointment = Appointment.parseAppointmentDescription(APPOINTMENT_DESCRIPTION_STUB);
+
+        Person newPerson = new Person(updatedPerson.getName(), updatedPerson.getPhone(), updatedPerson.getEmail(),
+                updatedPerson.getAddress(), updatedPerson.getNextOfKinName(), updatedPerson.getNextOfKinPhone(),
+                updatedPerson.getFinancialPlans(), updatedPerson.getTags(), newAppointment);
+
+        expectedModel.setPerson(updatedPerson, newPerson);
+
+        assertCommandSuccess(new ConfirmOverrideCommand(newAppointment, personToEdit), model,
+                ConfirmOverrideCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+}


### PR DESCRIPTION
Currently, when scheduling an appointment with a person with an appointment scheduled, the schedule command overrides the old appointment without the users knowledge.

This fix keeps the implementation of this overriding appointment but adds a prompt that lets users know the current appointment scheduled and asks the user if he would like to override the appointment

This is done to enable schedule to have dual functionality of adding and editting as well as a reminder of a potentially forgotten appointment with a person and also as a quick way to override past appointments with a new one.

Fixes #100 