### PR TITLE
Update CompleteCommand to only accept either Index or LocalDate

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CompleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CompleteCommand.java
@@ -8,7 +8,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Consumer;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
@@ -48,31 +47,29 @@ public class CompleteCommand extends Command {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
 
-        Consumer<Index> editByIndex = index -> {
-            Person personToEdit = lastShownList.get(index.getZeroBased());
-            Person edittedPerson = createPersonWithoutAppointment(personToEdit);
-
-            model.setPerson(personToEdit, edittedPerson);
-        };
-
         Optional<Index> index = completeDescriptor.getIndex();
+
+        // if Index present, edit Model by index
         if (index.isPresent()) {
             if (index.get().getZeroBased() >= lastShownList.size()) {
                 throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
             }
 
-            Person person = lastShownList.get(index.get().getZeroBased());
-            if (person.hasNullAppointment()) {
+            Person personToEdit = lastShownList.get(index.get().getZeroBased());
+            if (personToEdit.hasNullAppointment()) {
                 throw new CommandException(MESSAGE_PERSON_NO_APPOINTMENT);
             }
+
+            Person edittedPerson = createPersonWithoutAppointment(personToEdit);
+
+            model.setPerson(personToEdit, edittedPerson);
         }
 
-        // if Index present, edit Model by Person Index
-        completeDescriptor.getIndex().ifPresent(editByIndex);
+        Optional<LocalDate> date = completeDescriptor.getDate();
 
         // if Date present, edit Model by Date;
-        if (completeDescriptor.getDate().isPresent()) {
-            if (!model.clearAppointments(completeDescriptor.getDate().orElse(null))) {
+        if (date.isPresent()) {
+            if (!model.clearAppointments(date.orElse(null))) {
                 throw new CommandException(MESSAGE_DATE_NO_APPOINTMENT);
             }
         }

--- a/src/main/java/seedu/address/logic/parser/CompleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CompleteCommandParser.java
@@ -41,6 +41,11 @@ public class CompleteCommandParser implements Parser<CompleteCommand> {
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_APPOINTMENT_DATE);
 
+        if (!completeDescriptor.getIndex().isEmpty() & argMultimap.getValue(PREFIX_APPOINTMENT_DATE).isPresent()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    CompleteCommand.MESSAGE_USAGE));
+        }
+
         if (argMultimap.getValue(PREFIX_APPOINTMENT_DATE).isPresent()) {
             LocalDate date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_APPOINTMENT_DATE).get());
             completeDescriptor.setDate(date);

--- a/src/test/java/seedu/address/logic/parser/CompleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CompleteCommandParserTest.java
@@ -22,11 +22,6 @@ class CompleteCommandParserTest {
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, CompleteCommand.MESSAGE_USAGE);
     private CompleteCommandParser parser = new CompleteCommandParser();
-    @Test
-    public void parse_missingParts_failure() {
-        //no index or date specified
-        assertParseFailure(parser, " ", MESSAGE_INVALID_FORMAT);
-    }
 
     @Test
     public void parse_invalidPreamble_failure() {
@@ -44,7 +39,7 @@ class CompleteCommandParserTest {
     }
 
     @Test
-    public void parse_invalidValue_failure() {
+    public void parse_invalidDate_failure() {
         //Invalid date format
         assertParseFailure(parser, DATE_DESC + "01 May 2023", MESSAGE_INVALID_DATE_FORMAT);
         assertParseFailure(parser, DATE_DESC + "01-05", MESSAGE_INVALID_DATE_FORMAT);
@@ -55,6 +50,15 @@ class CompleteCommandParserTest {
         assertParseFailure(parser, DATE_DESC + "01-13-2023", MESSAGE_INVALID_DATE);
     }
 
+    @Test
+    public void parse_invalidArgs_failure() {
+        //no index or date specified
+        assertParseFailure(parser, " ", MESSAGE_INVALID_FORMAT);
+
+        //both index and date specified
+        assertParseFailure(parser, INDEX_FIRST_PERSON.getOneBased() + DATE_DESC + "01-05-2023",
+                MESSAGE_INVALID_FORMAT);
+    }
     @Test
     public void parse_duplicateFields_failure() {
         String userInput = DATE_DESC + "01-05-2023" + DATE_DESC + "02-10-2023";


### PR DESCRIPTION
Previously, there was a bug that allowed both arguments to be input together

Updated the parser to only allow either one of the arguments but not both at the same time, else the command usage message will be rendered to user.

This is to make it clearer to prevent confusing behaviour for the user

Resolves #199 